### PR TITLE
Changed messner to main branch.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -47,7 +47,7 @@
 [submodule "tools/compilation/messner/messner"]
 	path = tools/compilation/messner/messner
 	url = git@github.com:everest-h2020/messner.git
-	branch = cfdlang
+	branch = main
 [submodule "tools/runtime/evkit/evkit"]
 	path = tools/runtime/evkit/evkit
 	url = https://code.it4i.cz/everest/evkit.git


### PR DESCRIPTION
Since `messner` is now living in the main branch, I've changed the submodule.

Please keep in mind that I didn't actually pin the submodule to a particular hash, only to the branch ref, as before. At the moment, no version incompatibilities can be introduced by messner, but it is still lacking some commits for the demo.