### PR TITLE
Add explicit link to EvKit repo

### DIFF
--- a/tools/runtime/evkit/README.md
+++ b/tools/runtime/evkit/README.md
@@ -1,5 +1,5 @@
 # evkit
-Distributed runtime for the Everest project.
+Distributed runtime for the Everest project. The EvKit repository is located [here](https://code.it4i.cz/everest/evkit.git).
 
 ## Installation
 Clone this repository recursively:


### PR DESCRIPTION
Because the submodule link is not clickable by GitHub, because it points to a non-GitHub repo.